### PR TITLE
Refactor ShapeRenderable to use ShapeKind ADT

### DIFF
--- a/examples/bouncing_balls/src/main.rs
+++ b/examples/bouncing_balls/src/main.rs
@@ -1,7 +1,7 @@
 extern crate sky_renderer;
 
 use sky_renderer::core::{App, Color, Renderable, Renderer, Window};
-use sky_renderer::graphics2d::shapes::{Circle, ShapeRenderable, ShapeStyle};
+use sky_renderer::graphics2d::shapes::{Circle, ShapeKind, ShapeRenderable, ShapeStyle};
 
 use rand::{rngs::ThreadRng, Rng};
 use rand::distr::Uniform;
@@ -32,7 +32,7 @@ fn main() {
             ShapeRenderable::from_shape(
                 0.0,
                 0.0,
-                Box::new(Circle::new(BALL_RADIUS)),
+                ShapeKind::Circle(Circle::new(BALL_RADIUS)),
                 ShapeStyle {
                     fill: Some(Color::from_rgb(
                         rand_f32(&mut rng),

--- a/examples/bouncing_balls_instanced/src/main.rs
+++ b/examples/bouncing_balls_instanced/src/main.rs
@@ -1,7 +1,7 @@
 extern crate sky_renderer;
 
 use sky_renderer::core::{App, Color, Renderable, Renderer, Vec2, Window};
-use sky_renderer::graphics2d::shapes::{Circle, ShapeRenderable, ShapeStyle};
+use sky_renderer::graphics2d::shapes::{Circle, ShapeKind, ShapeRenderable, ShapeStyle};
 
 use rand::{rngs::ThreadRng, Rng};
 use rand::distr::Uniform;
@@ -28,7 +28,7 @@ fn main() {
     let mut dots = ShapeRenderable::from_shape(
         0.0,
         0.0,
-        Box::new(Circle::new(BALL_RADIUS)),
+        ShapeKind::Circle(Circle::new(BALL_RADIUS)),
         ShapeStyle {
             fill: Some(Color::from_rgb(0.254902, 0.411765, 0.882353)),
             stroke_color: None,

--- a/examples/bouncing_balls_ws_client/src/main.rs
+++ b/examples/bouncing_balls_ws_client/src/main.rs
@@ -1,5 +1,5 @@
 use sky_renderer::core::{App, Color, Renderable, Renderer, Window};
-use sky_renderer::graphics2d::shapes::{Circle, ShapeRenderable, ShapeStyle};
+use sky_renderer::graphics2d::shapes::{Circle, ShapeKind, ShapeRenderable, ShapeStyle};
 
 use std::sync::{Arc, RwLock};
 use tokio::runtime::Runtime;
@@ -50,7 +50,7 @@ fn main() {
                 shapes.push(ShapeRenderable::from_shape(
                     snap.x,
                     snap.y,
-                    Box::new(Circle::new(BALL_RADIUS)),
+                    ShapeKind::Circle(Circle::new(BALL_RADIUS)),
                     ShapeStyle {
                         fill: Some(Color::from_rgb(snap.r, snap.g, snap.b)),
                         stroke_color: None,

--- a/examples/instancing.rs
+++ b/examples/instancing.rs
@@ -1,7 +1,7 @@
 extern crate sky_renderer;
 
 use sky_renderer::core::{App, Color, Renderable, Renderer, Vec2, Window};
-use sky_renderer::graphics2d::shapes::{Circle, ShapeRenderable, ShapeStyle};
+use sky_renderer::graphics2d::shapes::{Circle, ShapeKind, ShapeRenderable, ShapeStyle};
 
 const WIDTH: i32 = 1600;
 const HEIGHT: i32 = 1000;
@@ -24,7 +24,7 @@ fn main() {
     let mut dots = ShapeRenderable::from_shape(
         0.0,
         0.0,
-        Box::new(Circle::new(RADIUS)),
+        ShapeKind::Circle(Circle::new(RADIUS)),
         ShapeStyle {
             fill: Some(Color::from_rgb(STEEL_BLUE.0, STEEL_BLUE.1, STEEL_BLUE.2)),
             stroke_color: None,

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -2,8 +2,8 @@ extern crate sky_renderer;
 
 use sky_renderer::core::{App, Color, Renderable, Renderer, Window};
 use sky_renderer::graphics2d::shapes::{
-    Arc, Circle, Ellipse, Line, MultiPoint, Point, Polygon, Polyline, Rectangle,
-    RoundedRectangle, ShapeRenderable, ShapeStyle, Triangle,
+    Arc, Circle, Ellipse, Line, MultiPoint, Polygon, Polyline, Rectangle, RoundedRectangle,
+    ShapeKind, ShapeRenderable, ShapeStyle, Triangle,
 };
 
 fn create_equilateral_triangle() -> [(f32, f32); 3] {
@@ -95,91 +95,91 @@ fn main() {
         ShapeRenderable::from_shape(
             100.0,
             200.0,
-            Box::new(Line::new(300.0, 250.0)),
+            ShapeKind::Line(Line::new(300.0, 250.0)),
             stroke_style(Color::from_rgb(0.0, 1.0, 0.0), 1.0),
         ),
         // Polyline starting at (100, 300)
         ShapeRenderable::from_shape(
             100.0,
             300.0,
-            Box::new(Polyline::new(polyline_points)),
+            ShapeKind::Polyline(Polyline::new(polyline_points)),
             stroke_style(Color::from_rgb(1.0, 0.0, 0.0), 10.0),
         ),
         // Arc centered at (700, 600)
         ShapeRenderable::from_shape(
             700.0,
             600.0,
-            Box::new(Arc::new(70.0, 0.0, std::f32::consts::PI / 2.0)),
+            ShapeKind::Arc(Arc::new(70.0, 0.0, std::f32::consts::PI / 2.0)),
             stroke_style(Color::from_rgb(0.0, 0.0, 1.0), 10.0),
         ),
         // Rectangle at (50, 50)
         ShapeRenderable::from_shape(
             50.0,
             50.0,
-            Box::new(Rectangle::new(200.0, 80.0)),
+            ShapeKind::Rectangle(Rectangle::new(200.0, 80.0)),
             fill_style(Color::from_rgb(0.2, 0.5, 0.9)),
         ),
         // Triangle at (50, 50)
         ShapeRenderable::from_shape(
             50.0,
             50.0,
-            Box::new(Triangle::new(create_equilateral_triangle())),
+            ShapeKind::Triangle(Triangle::new(create_equilateral_triangle())),
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // Rectangle at (400, 200)
         ShapeRenderable::from_shape(
             400.0,
             200.0,
-            Box::new(Rectangle::new(100.0, 50.0)),
+            ShapeKind::Rectangle(Rectangle::new(100.0, 50.0)),
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // Circle at (400, 400)
         ShapeRenderable::from_shape(
             400.0,
             400.0,
-            Box::new(Circle::new(50.0)),
+            ShapeKind::Circle(Circle::new(50.0)),
             fill_style(Color::from_rgb(0.0, 0.0, 1.0)),
         ),
         // Point at (600, 300)
         ShapeRenderable::from_shape(
             600.0,
             300.0,
-            Box::new(Point::new()),
+            ShapeKind::Point,
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // MultiPoint (sine wave)
         ShapeRenderable::from_shape(
             sine_x,
             sine_y,
-            Box::new(MultiPoint::new(sine_wave_rel)),
+            ShapeKind::MultiPoint(MultiPoint::new(sine_wave_rel)),
             fill_style(Color::from_rgb(0.0, 0.0, 1.0)),
         ),
         // Ellipse at (600, 200)
         ShapeRenderable::from_shape(
             600.0,
             200.0,
-            Box::new(Ellipse::new(80.0, 40.0)),
+            ShapeKind::Ellipse(Ellipse::new(80.0, 40.0)),
             fill_style(Color::from_rgb(0.5, 0.2, 0.8)),
         ),
         // Rounded rectangle at (100, 600)
         ShapeRenderable::from_shape(
             100.0,
             600.0,
-            Box::new(RoundedRectangle::new(200.0, 80.0, 10.0)),
+            ShapeKind::RoundedRectangle(RoundedRectangle::new(200.0, 80.0, 10.0)),
             fill_style(Color::from_rgb(0.3, 0.6, 0.9)),
         ),
         // Polygon (hexagon)
         ShapeRenderable::from_shape(
             poly_x,
             poly_y,
-            Box::new(Polygon::new(polygon_rel)),
+            ShapeKind::Polygon(Polygon::new(polygon_rel)),
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
-        // Rectangle using from_shape (was already using it)
+        // Rectangle using from_shape
         ShapeRenderable::from_shape(
             600.0,
             400.0,
-            Box::new(Rectangle::new(100.0, 50.0)),
+            ShapeKind::Rectangle(Rectangle::new(100.0, 50.0)),
             fill_style(Color::from_rgb(0.0, 1.0, 0.0)),
         ),
         // Images (still use dedicated methods)

--- a/examples/shapes_with_zoom.rs
+++ b/examples/shapes_with_zoom.rs
@@ -2,7 +2,7 @@ extern crate sky_renderer;
 
 use sky_renderer::core::{App, Color, Renderable, Renderer, Window};
 use sky_renderer::graphics2d::shapes::{
-    Circle, Ellipse, Line, MultiPoint, Point, Polygon, Polyline, Rectangle, RoundedRectangle,
+    Circle, Ellipse, Line, MultiPoint, Polygon, Polyline, Rectangle, RoundedRectangle, ShapeKind,
     ShapeRenderable, ShapeStyle,
 };
 
@@ -80,78 +80,78 @@ fn main() {
         ShapeRenderable::from_shape(
             100.0,
             200.0,
-            Box::new(Line::new(300.0, 250.0)),
+            ShapeKind::Line(Line::new(300.0, 250.0)),
             stroke_style(Color::from_rgb(0.0, 1.0, 0.0), 1.0),
         ),
         // Polyline starting at (100, 300)
         ShapeRenderable::from_shape(
             100.0,
             300.0,
-            Box::new(Polyline::new(polyline_points)),
+            ShapeKind::Polyline(Polyline::new(polyline_points)),
             stroke_style(Color::from_rgb(0.0, 1.0, 0.0), 10.0),
         ),
         // Rectangle at (50, 50)
         ShapeRenderable::from_shape(
             50.0,
             50.0,
-            Box::new(Rectangle::new(200.0, 80.0)),
+            ShapeKind::Rectangle(Rectangle::new(200.0, 80.0)),
             fill_style(Color::from_rgb(0.2, 0.5, 0.9)),
         ),
         // Rectangle at (400, 200)
         ShapeRenderable::from_shape(
             400.0,
             200.0,
-            Box::new(Rectangle::new(100.0, 50.0)),
+            ShapeKind::Rectangle(Rectangle::new(100.0, 50.0)),
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // Circle at (400, 400)
         ShapeRenderable::from_shape(
             400.0,
             400.0,
-            Box::new(Circle::new(50.0)),
+            ShapeKind::Circle(Circle::new(50.0)),
             fill_style(Color::from_rgb(0.0, 0.0, 1.0)),
         ),
         // Point at (600, 300)
         ShapeRenderable::from_shape(
             600.0,
             300.0,
-            Box::new(Point::new()),
+            ShapeKind::Point,
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // MultiPoint at (600, 100)
         ShapeRenderable::from_shape(
             600.0,
             100.0,
-            Box::new(MultiPoint::new(multipoint_points)),
+            ShapeKind::MultiPoint(MultiPoint::new(multipoint_points)),
             fill_style(Color::from_rgb(0.0, 0.0, 1.0)),
         ),
         // Ellipse at (600, 200)
         ShapeRenderable::from_shape(
             600.0,
             200.0,
-            Box::new(Ellipse::new(80.0, 40.0)),
+            ShapeKind::Ellipse(Ellipse::new(80.0, 40.0)),
             fill_style(Color::from_rgb(0.5, 0.2, 0.8)),
         ),
         // Rounded rectangle at (100, 600)
         ShapeRenderable::from_shape(
             100.0,
             600.0,
-            Box::new(RoundedRectangle::new(200.0, 80.0, 10.0)),
+            ShapeKind::RoundedRectangle(RoundedRectangle::new(200.0, 80.0, 10.0)),
             fill_style(Color::from_rgb(0.3, 0.6, 0.9)),
         ),
         // Polygon (hexagon) at (600, 600)
         ShapeRenderable::from_shape(
             600.0,
             600.0,
-            Box::new(Polygon::new(polygon_points)),
+            ShapeKind::Polygon(Polygon::new(polygon_points)),
             fill_style(Color::from_rgb(1.0, 0.0, 0.0)),
         ),
         // Rectangle using from_shape
         ShapeRenderable::from_shape(
             600.0,
             400.0,
-            Box::new(Rectangle::new(100.0, 50.0)),
-            ShapeStyle::default(),
+            ShapeKind::Rectangle(Rectangle::new(100.0, 50.0)),
+            fill_style(Color::from_rgb(0.0, 1.0, 0.0)),
         ),
         // Images
         ShapeRenderable::image_with_size(200.0, 300.0, "images/smiley.png", 40.0, 40.0),

--- a/src/graphics2d/shapes/mod.rs
+++ b/src/graphics2d/shapes/mod.rs
@@ -1,51 +1,26 @@
 mod shaperenderable;
 
-use std::any::Any;
 pub use shaperenderable::ShapeRenderable;
 pub use shaperenderable::ShapeStyle;
 
-#[derive(Debug, Clone)]
 pub enum ShapeKind {
     Point,
-    MultiPoint,
-    Line,
-    Polyline,
-    Triangle,
-    Rectangle,
-    RoundedRectangle,
-    Polygon,
-    Circle,
-    Ellipse,
-    Arc,
-    Image,
+    MultiPoint(MultiPoint),
+    Line(Line),
+    Polyline(Polyline),
+    Triangle(Triangle),
+    Rectangle(Rectangle),
+    RoundedRectangle(RoundedRectangle),
+    Polygon(Polygon),
+    Circle(Circle),
+    Ellipse(Ellipse),
+    Arc(Arc),
+    Image(Image),
 }
-/// A trait representing a 2D shape.
-pub trait Shape {
-    fn kind(&self) -> ShapeKind;
-    fn as_any(&self) -> &dyn Any;
-}
-
-pub fn cast_shape<T: Shape + 'static>(shape: &dyn Shape) -> &T {
-    shape
-        .as_any()
-        .downcast_ref::<T>()
-        .expect("Invalid shape type")
-}
-
 pub struct Point;
 impl Point{
     pub fn new() -> Self{
         Self{}
-    }
-}
-
-impl Shape for Point {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Point
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -59,15 +34,6 @@ impl MultiPoint {
     }
 }
 
-impl Shape for MultiPoint {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::MultiPoint
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
 
 pub struct Line {
     pub x2: f32,
@@ -80,16 +46,6 @@ impl Line {
     }
 }
 
-impl Shape for Line {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Line
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 pub struct Polyline {
     pub points: Vec<(f32, f32)>,
 }
@@ -99,17 +55,6 @@ impl Polyline {
         Self { points }
     }
 }
-
-impl Shape for Polyline {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Polyline
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 pub struct Triangle {
     pub vertices: [(f32, f32); 3],
 }
@@ -120,15 +65,6 @@ impl Triangle {
     }
 }
 
-impl Shape for Triangle {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Triangle
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
 
 pub struct Rectangle {
     pub width: f32,
@@ -138,16 +74,6 @@ pub struct Rectangle {
 impl Rectangle {
     pub fn new(width: f32, height: f32) -> Self {
         Self { width, height }
-    }
-}
-
-impl Shape for Rectangle {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Rectangle
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -163,16 +89,6 @@ impl RoundedRectangle {
     }
 }
 
-impl Shape for RoundedRectangle {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::RoundedRectangle
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 pub struct Polygon {
     pub points: Vec<(f32, f32)>,
 }
@@ -183,16 +99,6 @@ impl Polygon {
     }
 }
 
-impl Shape for Polygon {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Polygon
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 pub struct Circle {
     pub radius: f32,
 }
@@ -200,16 +106,6 @@ pub struct Circle {
 impl Circle {
     pub fn new(radius: f32) -> Self {
         Self { radius }
-    }
-}
-
-impl Shape for Circle {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Circle
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -224,16 +120,6 @@ impl Ellipse {
     }
 }
 
-impl Shape for Ellipse {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Ellipse
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 pub struct Image {
     pub width: f32,
     pub height: f32,
@@ -242,16 +128,6 @@ pub struct Image {
 impl Image {
     pub fn new(width: f32, height: f32) -> Self {
         Self { width, height }
-    }
-}
-
-impl Shape for Image {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Image
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -264,15 +140,5 @@ pub struct Arc{
 impl Arc {
     pub fn new(radius: f32, start_angle: f32, end_angle: f32) -> Self {
         Self { radius, start_angle, end_angle }
-    }
-}
-
-impl Shape for Arc {
-    fn kind(&self) -> ShapeKind {
-        ShapeKind::Arc
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }


### PR DESCRIPTION
## Summary
- Replace trait objects (`Box<dyn Shape>`) and dynamic casting (`cast_shape`) with algebraic data types
- Update `from_shape` and private constructors to use concrete types via enum pattern matching
- Refactor `ToSvg` implementation to directly match on `ShapeKind` variants
- Update all examples to use the new `ShapeKind::Variant(Type::new(...))` syntax

## Test plan
- [x] `cargo build` passes with no errors
- [x] `cargo build --examples` passes with no warnings
- [x] `cargo run --example shapes` renders correctly
- [x] `cargo run --example shapes_with_zoom` works with zoom functionality
- [x] `cargo run --example instancing` works with instanced rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)